### PR TITLE
Added option for forcing samba 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ $ sudo mount.cifs \
 	password=$3DS_PASS,\
 	ip=$3DS_LOCALIP,\
 	servern=$3DS_NAME,\
-	uid=$USER,gid=users,nounix /mnt
+	uid=$USER,gid=users,nounix,\
+	vers=1.0 /mnt
 ```
 That command will successfully mount your 3DS's microSD card to `/mnt`. Please note that `sudo` is required.
 


### PR DESCRIPTION
When attempting to mount, the error 'Host is down' was occuring a split second after it connecting (3DS makes the connection sound). This is resolved by forcing samba 1.0